### PR TITLE
ci: add GHA layer caching and workflow optimizations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,22 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - '.github/dependabot.yml'
 
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - '.github/dependabot.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   IMAGE_NAME: pwgen
@@ -22,12 +36,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - name: Build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           load: true
           tags: ${{ env.IMAGE_NAME }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test
         run: docker run -i --rm $IMAGE_NAME -sycnB -1 25
@@ -79,9 +98,10 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          build-args: MAJOR_VERSION=${{ env.MAJOR_VERSION }}
           push: true
           provenance: mode=max
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,10 @@ name: Check Shell scripts
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shfmt:
     runs-on: ubuntu-latest
@@ -14,7 +18,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: docker run --rm -v "$(pwd)":/sh -w /sh mvdan/shfmt:v3.1.1 -sr -i 2 -l -w -ci .
+      - uses: mfinelli/setup-shfmt@a25fda4c1fe115aec0f85e04126610841bc3141d # v4.0.1
+        with:
+          shfmt-version: 3.1.1
+      - run: shfmt -sr -i 2 -ci -l -w .
       - run: git diff --color --exit-code
 
   shellcheck:


### PR DESCRIPTION
## Summary

The workflows had no caching configured — every run rebuilt Docker images from scratch. This PR adds GitHub Actions layer caching and cleans up a few other inefficiencies.

## Changes

### `docker-publish.yml`
- **Docker layer cache**: Add `cache-from: type=gha` / `cache-to: type=gha,mode=max` to both `test` and `push` build steps. Layers from the `test` job are reused by `push`'s amd64 platform.
- **Buildx in `test` job**: The legacy Docker builder doesn't support `type=gha`; adding `setup-buildx-action` enables it.
- **Concurrency**: Cancel superseded in-flight runs on the same PR; queue on `main` pushes.
- **`paths-ignore`**: Doc-only edits (`README.md`, `LICENSE`, etc.) no longer trigger Docker builds.
- **Remove dead `build-args`**: `MAJOR_VERSION` was passed but never defined and the `Dockerfile` has no matching `ARG`.

### `shellcheck.yml`
- **Native shfmt binary**: Replace `docker run mvdan/shfmt:v3.1.1` (image pull on every PR) with `mfinelli/setup-shfmt@v4.0.1` (SHA-pinned native action).
- **Concurrency**: Cancel superseded runs on the same PR.