### PR TITLE
chore(deps): update dependabot schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:30"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -18,8 +17,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:45"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -33,8 +31,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:45"
       timezone: "America/Toronto"
     pull-request-branch-name:


### PR DESCRIPTION
Updates all package ecosystems (github-actions, pre-commit, docker) to check for updates daily instead of weekly, enabling faster dependency updates and security patches.